### PR TITLE
Stratum server identification

### DIFF
--- a/scripts/main/manager.js
+++ b/scripts/main/manager.js
@@ -14,10 +14,11 @@ const Template = require('./template');
 ////////////////////////////////////////////////////////////////////////////////
 
 // Main Manager Function
-const Manager = function(poolConfig) {
+const Manager = function(poolConfig, portalConfig) {
 
   const _this = this;
   this.poolConfig = poolConfig;
+  this.portalConfig = portalConfig;
 
   const algorithm = _this.poolConfig.primary.coin.algorithms.mining;
   const shareMultiplier = Algorithms[algorithm].multiplier;
@@ -103,6 +104,7 @@ const Manager = function(poolConfig) {
     const shareError = function(error) {
       _this.emit('share', {
         job: jobId,
+        identifier: _this.portalConfig.identifier,
         ip: ipAddress,
         port: port,
         difficulty: difficulty,
@@ -228,6 +230,7 @@ const Manager = function(poolConfig) {
         header: headerHash,
         headerDiff: headerBigNum,
         height: job.rpcData.height,
+        identifier: _this.portalConfig.identifier,
         reward: job.rpcData.coinbasevalue,
         shareDiff: shareDiff.toFixed(8),
       };
@@ -246,6 +249,7 @@ const Manager = function(poolConfig) {
         hex: blockHex,
         header: headerHash,
         headerDiff: headerBigNum,
+        identifier: _this.portalConfig.identifier,
         shareDiff: shareDiff.toFixed(8),
       };
 
@@ -343,6 +347,7 @@ const Manager = function(poolConfig) {
         header: headerHash,
         headerDiff: headerBigNum,
         height: job.rpcData.height,
+        identifier: _this.portalConfig.identifier,
         reward: job.rpcData.coinbasevalue,
         shareDiff: shareDiff.toFixed(8),
       };
@@ -361,6 +366,7 @@ const Manager = function(poolConfig) {
         hex: blockHex,
         header: headerHash,
         headerDiff: headerBigNum,
+        identifier: _this.portalConfig.identifier,
         shareDiff: shareDiff.toFixed(8),
       };
 

--- a/scripts/main/pool.js
+++ b/scripts/main/pool.js
@@ -387,7 +387,7 @@ const Pool = function(poolConfig, portalConfig, authorizeFn, responseFn) {
   this.setupJobManager = function() {
 
     // Establish Pool Manager
-    _this.manager = new Manager(_this.poolConfig);
+    _this.manager = new Manager(_this.poolConfig, _this.portalConfig);
     _this.manager.on('newBlock', (blockTemplate) => {
       if (_this.stratum) {
         _this.stratum.broadcastMiningJobs(blockTemplate, true);

--- a/scripts/test/manager.test.js
+++ b/scripts/test/manager.test.js
@@ -146,20 +146,27 @@ const poolConfigKawpow = {
   },
 };
 
+const portalConfig = {
+  'settings': {
+    'identifier': 'master',
+  },
+};
+
 ////////////////////////////////////////////////////////////////////////////////
 
 describe('Test manager functionality', () => {
 
-  let configCopy, configKawpowCopy, rpcDataCopy, rpcDataKawpowCopy;
+  let configCopy, configKawpowCopy, portalConfigCopy, rpcDataCopy, rpcDataKawpowCopy;
   beforeEach(() => {
     configCopy = JSON.parse(JSON.stringify(poolConfig));
-    rpcDataCopy = JSON.parse(JSON.stringify(rpcData));
     configKawpowCopy = JSON.parse(JSON.stringify(poolConfigKawpow));
+    portalConfigCopy = JSON.parse(JSON.stringify(portalConfig));
+    rpcDataCopy = JSON.parse(JSON.stringify(rpcData));
     rpcDataKawpowCopy = JSON.parse(JSON.stringify(rpcDataKawpow));
   });
 
   test('Test initial manager calculations', () => {
-    const manager = new Manager(configCopy);
+    const manager = new Manager(configCopy, portalConfigCopy);
     expect(manager.extraNonceCounter.size).toBe(4);
     expect(manager.extraNonceCounter.next().length).toBe(8);
     expect(manager.extraNoncePlaceholder).toStrictEqual(Buffer.from('f000000ff111111f', 'hex'));
@@ -168,13 +175,13 @@ describe('Test manager functionality', () => {
 
   test('Test job updates given auxpow initialization', () => {
     rpcDataCopy.auxData = auxData;
-    const manager = new Manager(configCopy);
+    const manager = new Manager(configCopy, portalConfigCopy);
     const response = manager.processTemplate(rpcDataCopy, true);
     expect(response).toBe(true);
   });
 
   test('Test job updates given new blockTemplate', () => {
-    const manager = new Manager(configCopy);
+    const manager = new Manager(configCopy, portalConfigCopy);
     manager.updateCurrentJob(rpcData);
     expect(typeof manager.currentJob).toBe('object');
     expect(manager.currentJob.rpcData.height).toBe(1);
@@ -183,7 +190,7 @@ describe('Test manager functionality', () => {
   });
 
   test('Test template updates given new blockTemplate [1]', () => {
-    const manager = new Manager(configCopy);
+    const manager = new Manager(configCopy, portalConfigCopy);
     const response1 = manager.processTemplate(rpcData, false);
     const response2 = manager.processTemplate(rpcData, false);
     expect(response1).toBe(true);
@@ -191,7 +198,7 @@ describe('Test manager functionality', () => {
   });
 
   test('Test template updates given new blockTemplate [2]', () => {
-    const manager = new Manager(configCopy);
+    const manager = new Manager(configCopy, portalConfigCopy);
     const response1 = manager.processTemplate(rpcDataCopy, false);
     rpcDataCopy.previousblockhash = '8719aefb83ef6583bd4c808bbe7d49b629a60b375fc6e36bee039530bc7727e2';
     const response2 = manager.processTemplate(rpcDataCopy, false);
@@ -200,7 +207,7 @@ describe('Test manager functionality', () => {
   });
 
   test('Test template updates given new blockTemplate [3]', () => {
-    const manager = new Manager(configCopy);
+    const manager = new Manager(configCopy, portalConfigCopy);
     const response1 = manager.processTemplate(rpcDataCopy, false);
     rpcDataCopy.previousblockhash = '8719aefb83ef6583bd4c808bbe7d49b629a60b375fc6e36bee039530bc7727e2';
     rpcDataCopy.height = 0;
@@ -210,7 +217,7 @@ describe('Test manager functionality', () => {
   });
 
   test('Test share submission process [1]', () => {
-    const manager = new Manager(configCopy);
+    const manager = new Manager(configCopy, portalConfigCopy);
     manager.processTemplate(rpcDataCopy, false);
     const submission = {
       extraNonce1: 0,
@@ -227,7 +234,7 @@ describe('Test manager functionality', () => {
   });
 
   test('Test share submission process [2]', () => {
-    const manager = new Manager(configCopy);
+    const manager = new Manager(configCopy, portalConfigCopy);
     manager.processTemplate(rpcDataCopy, false);
     const submission = {
       extraNonce1: 0,
@@ -244,7 +251,7 @@ describe('Test manager functionality', () => {
   });
 
   test('Test share submission process [3]', () => {
-    const manager = new Manager(configCopy);
+    const manager = new Manager(configCopy, portalConfigCopy);
     manager.processTemplate(rpcDataCopy, false);
     const submission = {
       extraNonce1: 0,
@@ -261,7 +268,7 @@ describe('Test manager functionality', () => {
   });
 
   test('Test share submission process [4]', () => {
-    const manager = new Manager(configCopy);
+    const manager = new Manager(configCopy, portalConfigCopy);
     manager.processTemplate(rpcDataCopy, false);
     const submission = {
       extraNonce1: 0,
@@ -278,7 +285,7 @@ describe('Test manager functionality', () => {
   });
 
   test('Test share submission process [5]', () => {
-    const manager = new Manager(configCopy);
+    const manager = new Manager(configCopy, portalConfigCopy);
     manager.processTemplate(rpcDataCopy, false);
     const submission = {
       extraNonce1: 0,
@@ -295,7 +302,7 @@ describe('Test manager functionality', () => {
   });
 
   test('Test share submission process [6]', () => {
-    const manager = new Manager(configCopy);
+    const manager = new Manager(configCopy, portalConfigCopy);
     manager.processTemplate(rpcDataCopy, false);
     const submission = {
       extraNonce1: '00000001'.toString('hex'),
@@ -312,7 +319,7 @@ describe('Test manager functionality', () => {
   });
 
   test('Test share submission process [7]', () => {
-    const manager = new Manager(configCopy);
+    const manager = new Manager(configCopy, portalConfigCopy);
     manager.processTemplate(rpcDataCopy, false);
     const submission = {
       extraNonce1: '00000001'.toString('hex'),
@@ -328,7 +335,7 @@ describe('Test manager functionality', () => {
   });
 
   test('Test share submission process [8]', () => {
-    const manager = new Manager(configCopy);
+    const manager = new Manager(configCopy, portalConfigCopy);
     manager.processTemplate(rpcDataCopy, false);
     const submission = {
       extraNonce1: '00000001'.toString('hex'),
@@ -346,7 +353,7 @@ describe('Test manager functionality', () => {
   });
 
   test('Test share submission process [9]', () => {
-    const manager = new Manager(configCopy);
+    const manager = new Manager(configCopy, portalConfigCopy);
     manager.processTemplate(rpcDataCopy, false);
     const submission = {
       extraNonce1: '00000001'.toString('hex'),
@@ -363,7 +370,7 @@ describe('Test manager functionality', () => {
   });
 
   test('Test share submission process [10]', () => {
-    const manager = new Manager(configCopy);
+    const manager = new Manager(configCopy, portalConfigCopy);
     manager.processTemplate(rpcDataCopy, false);
     const submission = {
       extraNonce1: '00000001'.toString('hex'),
@@ -380,7 +387,7 @@ describe('Test manager functionality', () => {
   });
 
   test('Test share submission process [11]', () => {
-    const manager = new Manager(configCopy);
+    const manager = new Manager(configCopy, portalConfigCopy);
     manager.processTemplate(rpcDataCopy, false);
     const submission = {
       extraNonce1: '00000001'.toString('hex'),
@@ -397,7 +404,7 @@ describe('Test manager functionality', () => {
   });
 
   test('Test share submission process [12]', () => {
-    const manager = new Manager(configCopy);
+    const manager = new Manager(configCopy, portalConfigCopy);
     manager.processTemplate(rpcDataCopy, false);
     const submission = {
       extraNonce1: '00000001'.toString('hex'),
@@ -414,7 +421,7 @@ describe('Test manager functionality', () => {
 
   test('Test share submission process [13]', () => {
     MockDate.set(1634742080841);
-    const manager = new Manager(configKawpowCopy);
+    const manager = new Manager(configKawpowCopy, portalConfigCopy);
     manager.processTemplate(rpcDataKawpowCopy, false);
     const submission = {
       extraNonce1: 0,
@@ -429,7 +436,7 @@ describe('Test manager functionality', () => {
 
   test('Test share submission process [14]', () => {
     MockDate.set(1634742080841);
-    const manager = new Manager(configKawpowCopy);
+    const manager = new Manager(configKawpowCopy, portalConfigCopy);
     manager.processTemplate(rpcDataKawpowCopy, false);
     const submission = {
       extraNonce1: 0,
@@ -444,7 +451,7 @@ describe('Test manager functionality', () => {
 
   test('Test share submission process [15]', () => {
     MockDate.set(1634742080841);
-    const manager = new Manager(configKawpowCopy);
+    const manager = new Manager(configKawpowCopy, portalConfigCopy);
     manager.processTemplate(rpcDataKawpowCopy, false);
     const submission = {
       extraNonce1: 0,
@@ -459,7 +466,7 @@ describe('Test manager functionality', () => {
 
   test('Test share submission process [16]', () => {
     MockDate.set(1634742080841);
-    const manager = new Manager(configKawpowCopy);
+    const manager = new Manager(configKawpowCopy, portalConfigCopy);
     manager.processTemplate(rpcDataKawpowCopy, false);
     const submission = {
       extraNonce1: 0,
@@ -474,7 +481,7 @@ describe('Test manager functionality', () => {
 
   test('Test share submission process [17]', () => {
     MockDate.set(1634742080841);
-    const manager = new Manager(configKawpowCopy);
+    const manager = new Manager(configKawpowCopy, portalConfigCopy);
     manager.processTemplate(rpcDataKawpowCopy, false);
     const submission = {
       extraNonce1: 0,
@@ -489,7 +496,7 @@ describe('Test manager functionality', () => {
 
   test('Test share submission process [18]', () => {
     MockDate.set(1634742080841);
-    const manager = new Manager(configKawpowCopy);
+    const manager = new Manager(configKawpowCopy, portalConfigCopy);
     manager.processTemplate(rpcDataKawpowCopy, false);
     const submission = {
       extraNonce1: '1952',
@@ -504,7 +511,7 @@ describe('Test manager functionality', () => {
 
   test('Test share submission process [19]', () => {
     MockDate.set(1634742080841);
-    const manager = new Manager(configKawpowCopy);
+    const manager = new Manager(configKawpowCopy, portalConfigCopy);
     manager.processTemplate(rpcDataKawpowCopy, false);
     const submission = {
       extraNonce1: '1952',
@@ -519,7 +526,7 @@ describe('Test manager functionality', () => {
 
   test('Test share submission process [20]', () => {
     MockDate.set(1634742080841);
-    const manager = new Manager(configKawpowCopy);
+    const manager = new Manager(configKawpowCopy, portalConfigCopy);
     manager.processTemplate(rpcDataKawpowCopy, false);
     const submission = {
       extraNonce1: '00',
@@ -534,7 +541,7 @@ describe('Test manager functionality', () => {
 
   test('Test share submission process [21]', () => {
     MockDate.set(1634742080841);
-    const manager = new Manager(configKawpowCopy);
+    const manager = new Manager(configKawpowCopy, portalConfigCopy);
     manager.processTemplate(rpcDataKawpowCopy, false);
     const submission = {
       extraNonce1: 'b750',
@@ -549,7 +556,7 @@ describe('Test manager functionality', () => {
 
   test('Test share submission process [22]', () => {
     MockDate.set(1634742080841);
-    const manager = new Manager(configKawpowCopy);
+    const manager = new Manager(configKawpowCopy, portalConfigCopy);
     manager.processTemplate(rpcDataKawpowCopy, false);
     const submission = {
       extraNonce1: '1952',
@@ -565,7 +572,7 @@ describe('Test manager functionality', () => {
 
   test('Test share submission process [23]', () => {
     MockDate.set(1634742080841);
-    const manager = new Manager(configKawpowCopy);
+    const manager = new Manager(configKawpowCopy, portalConfigCopy);
     manager.processTemplate(rpcDataKawpowCopy, false);
     const submission = {
       extraNonce1: '1952',

--- a/scripts/test/pool.test.js
+++ b/scripts/test/pool.test.js
@@ -722,6 +722,7 @@ describe('Test pool functionality', () => {
           header: null,
           headerDiff: null,
           height: 1,
+          identifier:'master',
           reward: 5000000000,
           shareDiff: 1,
         };
@@ -740,6 +741,7 @@ describe('Test pool functionality', () => {
           hex: Buffer.from('000011110000111100001111', 'hex'),
           header: null,
           headerDiff: null,
+          identifier:'master',
           shareDiff: 1,
         };
         pool.manager.emit('share', shareData, auxShareData, true);
@@ -780,6 +782,7 @@ describe('Test pool functionality', () => {
           header: null,
           headerDiff: null,
           height: 1,
+          identifier:'master',
           reward: 5000000000,
           shareDiff: 1,
         };
@@ -798,6 +801,7 @@ describe('Test pool functionality', () => {
           hex: Buffer.from('000011110000111100001111', 'hex'),
           header: null,
           headerDiff: null,
+          identifier:'master',
           shareDiff: 1,
         };
         pool.manager.emit('share', shareData, auxShareData, true);
@@ -862,6 +866,7 @@ describe('Test pool functionality', () => {
           header: null,
           headerDiff: null,
           height: 1,
+          identifier:'master',
           reward: 5000000000,
           shareDiff: 1,
         };
@@ -880,6 +885,7 @@ describe('Test pool functionality', () => {
           hex: Buffer.from('000011110000111100001111', 'hex'),
           header: null,
           headerDiff: null,
+          identifier:'master',
           shareDiff: 1,
         };
         pool.manager.emit('share', shareData, auxShareData, true);
@@ -952,6 +958,7 @@ describe('Test pool functionality', () => {
           header: null,
           headerDiff: null,
           height: 1,
+          identifier:'master',
           reward: 5000000000,
           shareDiff: 1,
         };
@@ -970,6 +977,7 @@ describe('Test pool functionality', () => {
           hex: Buffer.from('000011110000111100001111', 'hex'),
           header: null,
           headerDiff: null,
+          identifier:'master',
           shareDiff: 1,
         };
         pool.manager.emit('share', shareData, auxShareData, true);
@@ -1043,6 +1051,7 @@ describe('Test pool functionality', () => {
           header: null,
           headerDiff: null,
           height: 1,
+          identifier:'master',
           reward: 5000000000,
           shareDiff: 1,
         };
@@ -1061,6 +1070,7 @@ describe('Test pool functionality', () => {
           hex: Buffer.from('000011110000111100001111', 'hex'),
           header: null,
           headerDiff: null,
+          identifier:'master',
           shareDiff: 1,
         };
         pool.manager.emit('share', shareData, auxShareData, true);
@@ -1127,6 +1137,7 @@ describe('Test pool functionality', () => {
           header: null,
           headerDiff: null,
           height: 1,
+          identifier:'master',
           reward: 5000000000,
           shareDiff: 1,
         };
@@ -1145,6 +1156,7 @@ describe('Test pool functionality', () => {
           hex: Buffer.from('000011110000111100001111', 'hex'),
           header: null,
           headerDiff: null,
+          identifier:'master',
           shareDiff: 1,
         };
         pool.manager.emit('share', shareData, auxShareData, true);
@@ -1213,6 +1225,7 @@ describe('Test pool functionality', () => {
           header: null,
           headerDiff: null,
           height: 1,
+          identifier:'master',
           reward: 5000000000,
           shareDiff: 1,
         };
@@ -1231,6 +1244,7 @@ describe('Test pool functionality', () => {
           hex: Buffer.from('000011110000111100001111', 'hex'),
           header: null,
           headerDiff: null,
+          identifier:'master',
           shareDiff: 1,
         };
         pool.manager.emit('share', shareData, auxShareData, true);
@@ -1299,6 +1313,7 @@ describe('Test pool functionality', () => {
           header: null,
           headerDiff: null,
           height: 1,
+          identifier:'master',
           reward: 5000000000,
           shareDiff: 1,
         };
@@ -1317,6 +1332,7 @@ describe('Test pool functionality', () => {
           hex: Buffer.from('000011110000111100001111', 'hex'),
           header: null,
           headerDiff: null,
+          identifier:'master',
           shareDiff: 1,
         };
 
@@ -1489,6 +1505,7 @@ describe('Test pool functionality', () => {
               header: Buffer.from('000011110000111100001111', 'hex'),
               headerDiff: -1,
               height: 1,
+              identifier:'master',
               reward: 5000000000,
               shareDiff: 1,
             };
@@ -1507,6 +1524,7 @@ describe('Test pool functionality', () => {
               hex: Buffer.from('000011110000111100001111', 'hex'),
               header: Buffer.from('000011110000111100001111', 'hex'),
               headerDiff: -1,
+              identifier:'master',
               shareDiff: 1,
             };
             pool.manager.emit('share', shareData, auxShareData, false);


### PR DESCRIPTION
Stratum server can take the config.identifier parameter from config.js. It is included in all "emit('share'..." calls as a { identifier: String } parameter of shareData objects . This can be used to identify a specific stratum server in share submissions in a situation where multiple stratum servers are used.

An accompanying foundation-server PR will pass this data to Redis.