### PR TITLE
Changed key name to fix share type counting

### DIFF
--- a/scripts/main/manager.js
+++ b/scripts/main/manager.js
@@ -111,9 +111,9 @@ const Manager = function(poolConfig, portalConfig) {
         port: port,
         difficulty: difficulty,
         identifier: identifier,
-        worker: addrPrimary,
+        addrPrimary: addrPrimary,
         error: error[1],
-      }, null, null);
+      }, null, false);
       return { error: error, result: null };
     };
 


### PR DESCRIPTION
Shares that are stale or invalid were emitted with 'worker' instead of 'addrPrimary' as a key, causing incorrect counting of these share types.